### PR TITLE
FIX: Trigger image builds on push to v tags

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,9 @@
 name: create-doubtfire-deployment
 on:
+on:
+  push:
+    tags:
+      - 'v*'
   deployment:
   workflow_dispatch:
 jobs:
@@ -41,7 +45,7 @@ jobs:
         with:
           images: lmsdoubtfire/webserver
           tags: |
-            type=ref,event=branch
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -77,7 +81,7 @@ jobs:
         with:
           images: lmsdoubtfire/pdfGen
           tags: |
-            type=ref,event=branch
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -113,7 +117,7 @@ jobs:
         with:
           images: lmsdoubtfire/overseer
           tags: |
-            type=ref,event=branch
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
GitHub actions will run when a tag with pattern `v*` is pushed to the deploy repository.

- Resolves the issue where images are pushed to docker hub using the branch rather than the tag name.
- Triggers action on tag push