### PR TITLE
fix: change shebangs to specify bash (macOS uses zsh by default now)

### DIFF
--- a/change_remotes.sh
+++ b/change_remotes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
 APP_PATH=`cd "$APP_PATH"; pwd`

--- a/check.sh
+++ b/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Check for standard-version
 if ! command -v standard-version &> /dev/null; then

--- a/create-release-branch.sh
+++ b/create-release-branch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
 APP_PATH=`cd "$APP_PATH"; pwd`

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Check for standard-version
 if ! command -v standard-version &> /dev/null


### PR DESCRIPTION
Change the shebang to specify bash so the scripts will work correctly on macOS, which uses zsh by default now.