### PR TITLE
fix: add build directives to enable rebuilding containers with compose

### DIFF
--- a/development/docker-compose.full.yml
+++ b/development/docker-compose.full.yml
@@ -3,6 +3,7 @@ services:
   doubtfire-api:
     container_name: doubtfire-api
     image: lmsdoubtfire/doubtfire-api:development-dev
+    build: ../doubtfire-api
     ports:
       - "3000:3000"
     volumes:
@@ -29,6 +30,7 @@ services:
   doubtfire-web:
     container_name: doubtfire-web
     image: lmsdoubtfire/doubtfire-web:development-dev
+    build: ../doubtfire-web
     command: /bin/bash -c 'npm install; npm start'
     ports:
       - "4200:4200"
@@ -39,6 +41,7 @@ services:
 
   overseer-receive:
     image: lmsdoubtfire/doubtfire-api:development-dev
+    build: ../doubtfire-api
     env_file:
       - api.env
       - overseer.env

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   doubtfire-api:
     container_name: doubtfire-api
     image: lmsdoubtfire/doubtfire-api:development-dev
+    build: ../doubtfire-api
     ports:
       - "3000:3000"
     volumes:
@@ -73,6 +74,7 @@ services:
   doubtfire-web:
     container_name: doubtfire-web
     image: lmsdoubtfire/doubtfire-web:development-dev
+    build: ../doubtfire-web
     command: /bin/bash -c 'npm install; npm start'
     ports:
       - "4200:4200"


### PR DESCRIPTION
Our image on docker hub is updated very infrequently and we need a convenient way to rebuild the docker containers in order to make testing changes to our Dockerfile easier. Simply adding the `--build` option when calling docker compose will trigger a rebuild while the prebuilt images will still be pulled from docker hub without that option.