### PR TITLE
fix: force npm install in the vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
     {
       "label": "Serve web frontend",
       "type": "shell",
-      "command": "npm install && npm start",
+      "command": "npm install -f && npm start",
       "group": "build",
       "presentation": {
         "group": "buildGroup",


### PR DESCRIPTION
Fixes the frontend setup issues by running `npm install -f` instead.

