### PR TITLE
chore: update to debian bookworm and ruby 3.2

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,14 +1,15 @@
-FROM mcr.microsoft.com/devcontainers/ruby:3.1-bullseye
+FROM mcr.microsoft.com/devcontainers/ruby:3.2-bookworm
 
 # DEBIAN_FRONTEND=noninteractive is required to install tzdata in non interactive way
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
   && apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common \
-  && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-  && add-apt-repository "deb [arch=amd64,arm64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
   && curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
-  && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list
+  && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list
 
 ENV USER='vscode'
 ENV NODE_VERSION 18.15.0


### PR DESCRIPTION
Update container to debian bookworm and ruby 3.2, and stop using the deprecated `apt-key` tool for docker repo setup. Tested locally and everything seems okay. Please wait until the relevant PR on the backend repo is merged before merging this one.