### PR TITLE
enhance: add reverse proxy in devcontainer for CORS

### DIFF
--- a/.devcontainer/dev.code-workspace
+++ b/.devcontainer/dev.code-workspace
@@ -1,0 +1,25 @@
+{
+  "folders": [
+    {
+      "path": "/workspace",
+      "name": "doubtfire-deploy"
+    },
+    {
+      "path": "/workspace/doubtfire-api"
+    },
+    {
+      "path": "/workspace/doubtfire-web"
+    },
+    {
+      "path": "/workspace/doubtfire-overseer"
+    }
+  ],
+  "settings": {
+    "files.exclude": {
+      "doubtfire-api/**": true,
+      "doubtfire-web/**": true,
+      "doubtfire-overseer/**": true
+    },
+    "rubyLsp.formatter": "rubocop",
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,7 +75,7 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "workspaceFolder": "/workspace",
 
-  "forwardPorts": [3000, 4200, 9876],
+  "forwardPorts": [4200, 9876],
 
   "postCreateCommand": "/workspace/.devcontainer/post_create.sh",
   "postStartCommand": "/workspace/.devcontainer/post_start.sh",

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Temporary Items
 .apdisk
 
 # End of https://www.toptal.com/developers/gitignore/api/macos
+
+# IntelliJ config
+.idea

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Serve web frontend",
+      "label": "Frontend",
       "type": "shell",
       "command": "npm install -f && npm start",
       "group": "build",
@@ -19,7 +19,7 @@
       }
     },
     {
-      "label": "Serve Rails API",
+      "label": "Backend",
       "type": "shell",
       "command": "bundle install && rails s",
       "group": "build",
@@ -34,8 +34,25 @@
       }
     },
     {
+      "label": "Reverse Proxy",
+      "type": "shell",
+      "command": "caddy run --config Caddyfile",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated",
+        "echo": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    },
+    {
       "label": "Serve",
-      "dependsOn": ["Serve web frontend", "Serve Rails API"],
+      "dependsOn": ["Frontend", "Backend"],
       "group": "build",
       "runOptions": {
         "runOn": "folderOpen" // This starts both tasks when the container is started

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+{
+	auto_https off
+}
+
+http://127.0.0.1:4200 {
+	reverse_proxy /api/* localhost:3000
+	reverse_proxy /* localhost:4201
+}

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 
 ENV USER='vscode'
 ENV NODE_VERSION 18.15.0
-ENV NODE_ENV docker
+ENV NODE_ENV devcontainer
 ENV NPM_CONFIG_PREFIX="/home/${USER}/.npm-global"
 ENV BUNDLE_PATH=/home/${USER}/.gems
 
@@ -82,6 +82,16 @@ RUN apt-get update \
   && rm -rf /workspace/doubtfire-api/.ci-setup/texlive-install.sh \
   && rm -rf /install-tl-* \
   && mkdir /run/mysqld
+
+# Install caddy for reverse proxy
+RUN dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ;; \
+    arm64) ;; \
+    *) echo "unsupported architecture ${dpkgArch}"; exit 1 ;; \
+  esac \
+  && wget "https://caddyserver.com/api/download?os=linux&arch=${dpkgArch}" --output-document=/usr/local/bin/caddy \
+  && chmod +x /usr/local/bin/caddy
 
 USER "${USER}"
 


### PR DESCRIPTION
- Install caddy for reverse proxy (much easier to configure than nginx)
- Add workspace file with folders to fix Ruby LSP and make navigation easier
- Add vscode task to start caddy on launch

Depends on: https://github.com/doubtfire-lms/doubtfire-web/pull/840