### PR TITLE
added security headers inside production/proxy-nginx.conf to avoid cl…

### DIFF
--- a/production/shared-files/proxy-nginx.conf
+++ b/production/shared-files/proxy-nginx.conf
@@ -31,6 +31,11 @@ http {
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/key.key;
 
+        # Security Headers added here to Prevent Clickjacking
+        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none';" always;
+        #Mentioning headers to prevent XSS attacks and not to load any <iframe> on to the page
+
         # All api requests go to rails server
         location /api {
           proxy_set_header        Host $host;


### PR DESCRIPTION
_Base Branch: 9.x_

_Note: This PR is made to `doubtfire-lms/doubtfire-deploy` as an **upstream contribution** after peer review, AppAttack security verification, and mentor approval._

# Description

This PR adds **security headers** to the production reverse proxy configuration (`proxy-nginx.conf`) to mitigate **Clickjacking and potential XSS vulnerabilities** across all Doubtfire services.

- These headers are enforced at the **outer proxy level** to ensure a consistent and centralized security model for upstream services like `doubtfire-web`.
- The patch aligns with recommendations from the **AppAttack x OnTrack security audit** and modern web security best practices.

The corresponding inner doubtfire-web service PR is available at:  
🔗 [doubtfire-lms/doubtfire-web#946](https://github.com/doubtfire-lms/doubtfire-web/pull/946)

### Headers Added

- `X-Frame-Options: DENY`
- `Content-Security-Policy: default-src 'self', and frame-ancestors 'none'`

Both headers prevent the application from being embedded in `<iframe>` tags, effectively blocking clickjacking attempts.

## What was changed

- **Modified file**: `production/shared-files/proxy-nginx.conf`
- Added security headers to HTTP response block to be applied globally at reverse proxy layer.

_Fixes_: Clickjacking vulnerability reported by AppAttack using `<iframe>` injection methods.

# Reference PRs

- Related web-level changes: [doubtfire-lms/doubtfire-web#946](https://github.com/doubtfire-lms/doubtfire-web/pull/946)
- Original peer-reviewed PR: [thoth-tech/doubtfire-deploy PR](https://github.com/thoth-tech/doubtfire-deploy/pull/29)
- Background documentation: [Fix ClickJacking Vulnerability Documentation](https://github.com/thoth-tech/documentation/pull/593)

## Testing Summary

- Verified that all production responses now include the expected security headers.
  - `X-Frame-Options: DENY`
  - `Content-Security-Policy: default-src 'self', and frame-ancestors 'none'`
- Confirmed with browser DevTools that headers are applied globally and cannot be overridden downstream.
- Peer review and attack simulation by **AppAttack** confirmed that malicious framing attempts are blocked.
- Security validation approved by:
  - @ibi420 - confirmed header propagation and patch success
  - @lachlan-robinson - verified redundant defense and correct config
  - @DarrylO21 (AppAttack Lead) - validated real-world attack prevention
  - @theiris6 - verified production readiness
  - @aNebula - approved upstream PR after mentor review

## Checklist

- [x] Headers added only to `proxy-nginx.conf` (no unrelated changes)
- [x] Forked cleanly from `9.x` branch
- [x] All requested changes and reviews completed
- [x] Upstream web PR cross-linked

